### PR TITLE
Debug: fix hanging kernel on numpy invocation

### DIFF
--- a/gqcp-dev/Dockerfile
+++ b/gqcp-dev/Dockerfile
@@ -21,7 +21,7 @@ RUN conda --version
 
 ENV LIBINT_DATA_PATH=/usr/local/miniconda3/share/libint/2.6.0/basis
 ARG LIBINT_DATA_PATH=/usr/local/miniconda3/share/libint/2.6.0/basis
-RUN conda install -c conda-forge -c intel -c gqcg openmp=8.0.1 cmake=3.19.6 boost-cpp=1.75.0 eigen=3.3.9 blas=2.15 pybind11=2.6.2 benchmark=1.5.2 numpy=1.20.1 jupyter=1.0.0 libint=2.6.0 cint=3.0.17 mkl=2021.1.1 mkl-include=2021.1.1 mkl-static=2021.1.1 intel-openmp=2021.1.1 doxygen=1.9.1 graphviz=2.42.3 jupyter-book=0.10.2
+RUN conda install -c conda-forge -c intel -c gqcg openmp=8.0.1 cmake=3.20.2 boost-cpp=1.75.0 eigen=3.3.9 blas=2.15 pybind11=2.6.2 benchmark numpy=1.20.3 jupyter=1.0.0 libint=2.6.0 cint=3.0.17 mkl=2020.4 mkl-include=2020.4 mkl-static=2020.4 intel-openmp=2020.3 doxygen=1.9.1 graphviz=2.47.2 jupyter-book=0.10.2 libblas=*=*mkl
 
 RUN ldconfig
 


### PR DESCRIPTION
This PR will fix the hanging Python kernels when using Numpy in the GQCP Docker image as reported by @AaronDC60 and in issue https://github.com/GQCG/GQCP/issues/958.